### PR TITLE
Update LPoS Send NIX button

### DIFF
--- a/src/qt/forms/delegatedstaking.ui
+++ b/src/qt/forms/delegatedstaking.ui
@@ -414,10 +414,10 @@
               <item>
                <widget class="QPushButton" name="sendButton">
                 <property name="toolTip">
-                 <string>Convert Ghosted NIX</string>
+                 <string>Create a new LPoS Contract</string>
                 </property>
                 <property name="text">
-                 <string>&amp;Send NIX</string>
+                 <string>&amp;Create Contract</string>
                 </property>
                 <property name="autoDefault">
                  <bool>false</bool>


### PR DESCRIPTION
1. Replaces "Send NIX" button text with "Create Contract" (also gets around Alt+S shortcut which opened Settings menu instead of activating send button)
2. Replaces "Convert Ghosted NIX" tooltip text with "Create a new LPoS contract" 